### PR TITLE
Do not attach a usize len to slices - slices already have a length defined

### DIFF
--- a/matter/src/tlv/parser.rs
+++ b/matter/src/tlv/parser.rs
@@ -8,12 +8,11 @@ use super::{TagType, MAX_TAG_INDEX, TAG_MASK, TAG_SHIFT_BITS, TAG_SIZE_MAP, TYPE
 
 pub struct TLVList<'a> {
     buf: &'a [u8],
-    len: usize,
 }
 
 impl<'a> TLVList<'a> {
-    pub fn new(buf: &'a [u8], len: usize) -> TLVList<'a> {
-        TLVList { buf, len }
+    pub fn new(buf: &'a [u8]) -> TLVList<'a> {
+        TLVList { buf }
     }
 }
 
@@ -604,7 +603,7 @@ impl<'a> TLVList<'a> {
     pub fn iter(&self) -> TLVListIterator<'a> {
         TLVListIterator {
             current: 0,
-            left: self.len,
+            left: self.buf.len(),
             buf: self.buf,
         }
     }
@@ -691,14 +690,14 @@ impl<'a> Iterator for TLVContainerIterator<'a> {
 }
 
 pub fn get_root_node(b: &[u8]) -> Result<TLVElement, Error> {
-    TLVList::new(b, b.len())
+    TLVList::new(b)
         .iter()
         .next()
         .ok_or(Error::InvalidData)
 }
 
 pub fn get_root_node_struct(b: &[u8]) -> Result<TLVElement, Error> {
-    TLVList::new(b, b.len())
+    TLVList::new(b)
         .iter()
         .next()
         .ok_or(Error::InvalidData)?
@@ -706,7 +705,7 @@ pub fn get_root_node_struct(b: &[u8]) -> Result<TLVElement, Error> {
 }
 
 pub fn get_root_node_list(b: &[u8]) -> Result<TLVElement, Error> {
-    TLVList::new(b, b.len())
+    TLVList::new(b)
         .iter()
         .next()
         .ok_or(Error::InvalidData)?
@@ -714,7 +713,7 @@ pub fn get_root_node_list(b: &[u8]) -> Result<TLVElement, Error> {
 }
 
 pub fn print_tlv_list(b: &[u8]) {
-    let tlvlist = TLVList::new(b, b.len());
+    let tlvlist = TLVList::new(b);
 
     const MAX_DEPTH: usize = 9;
     info!("TLV list:");
@@ -779,7 +778,7 @@ mod tests {
     fn test_short_length_tag() {
         // The 0x36 is an array with a tag, but we leave out the tag field
         let b = [0x15, 0x36];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -790,7 +789,7 @@ mod tests {
     fn test_invalid_value_type() {
         // The 0x24 is a a tagged integer, here we leave out the integer value
         let b = [0x15, 0x1f, 0x0];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -801,7 +800,7 @@ mod tests {
     fn test_short_length_value_immediate() {
         // The 0x24 is a a tagged integer, here we leave out the integer value
         let b = [0x15, 0x24, 0x0];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -812,7 +811,7 @@ mod tests {
     fn test_short_length_value_string() {
         // This is a tagged string, with tag 0 and length 0xb, but we only have 4 bytes in the string
         let b = [0x15, 0x30, 0x00, 0x0b, 0x73, 0x6d, 0x61, 0x72];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -823,7 +822,7 @@ mod tests {
     fn test_valid_tag() {
         // The 0x36 is an array with a tag, here tag is 0
         let b = [0x15, 0x36, 0x0];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -844,7 +843,7 @@ mod tests {
     fn test_valid_value_immediate() {
         // The 0x24 is a a tagged integer, here the integer is 2
         let b = [0x15, 0x24, 0x1, 0x2];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -861,7 +860,7 @@ mod tests {
     fn test_valid_value_string() {
         // This is a tagged string, with tag 0 and length 4, and we have 4 bytes in the string
         let b = [0x15, 0x30, 0x5, 0x04, 0x73, 0x6d, 0x61, 0x72];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -912,7 +911,7 @@ mod tests {
             0x3, 0x6c, 0xd2, 0x9b, 0xa6, 0x39, 0x3e, 0xc7, 0xef, 0xad, 0x87, 0x14, 0xab, 0x71,
             0x82, 0x19, 0x26, 0x2, 0x3e, 0x0, 0x0, 0x0,
         ];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -972,7 +971,7 @@ mod tests {
     fn test_no_iterator_for_int() {
         // The 0x24 is a a tagged integer, here the integer is 2
         let b = [0x15, 0x24, 0x1, 0x2];
-        let tlvlist = TLVList::new(&b, b.len());
+        let tlvlist = TLVList::new(&b);
         let mut tlv_iter = tlvlist.iter();
         // Skip the 0x15
         tlv_iter.next();
@@ -1179,7 +1178,7 @@ mod tests {
             (TagType::Anonymous, ElementType::EndCnt),
         ];
 
-        let mut list_iter = TLVList::new(&b, b.len()).iter();
+        let mut list_iter = TLVList::new(&b).iter();
         let mut index = 0;
         loop {
             let element = list_iter.next();

--- a/matter/src/tlv/traits.rs
+++ b/matter/src/tlv/traits.rs
@@ -271,7 +271,7 @@ mod tests {
         let b = [
             21, 37, 0, 10, 0, 38, 1, 20, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
-        let root = TLVList::new(&b, b.len()).iter().next().unwrap();
+        let root = TLVList::new(&b).iter().next().unwrap();
         let test = TestDeriveSimple::from_tlv(&root).unwrap();
         assert_eq!(test.a, 10);
         assert_eq!(test.b, 20);
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn test_derive_fromtlv_str() {
         let b = [21, 37, 0, 10, 0, 0x30, 0x01, 0x03, 10, 11, 12, 0];
-        let root = TLVList::new(&b, b.len()).iter().next().unwrap();
+        let root = TLVList::new(&b).iter().next().unwrap();
         let test = TestDeriveStr::from_tlv(&root).unwrap();
         assert_eq!(test.a, 10);
         assert_eq!(test.b, OctetStr(&[10, 11, 12]));
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn test_derive_fromtlv_option() {
         let b = [21, 37, 0, 10, 0, 37, 2, 11, 0];
-        let root = TLVList::new(&b, b.len()).iter().next().unwrap();
+        let root = TLVList::new(&b).iter().next().unwrap();
         let test = TestDeriveOption::from_tlv(&root).unwrap();
         assert_eq!(test.a, 10);
         assert_eq!(test.b, None);

--- a/matter/tests/data_model/attributes.rs
+++ b/matter/tests/data_model/attributes.rs
@@ -291,8 +291,7 @@ fn get_tlvs<'a>(buf: &'a mut [u8], data: &[u16]) -> TLVElement<'a> {
         let _ = tw.u16(TagType::Anonymous, *e);
     }
     let _ = tw.end_container();
-    let wb_len = wb.as_borrow_slice().len();
-    let tlv_array = TLVList::new(wb.as_slice(), wb_len).iter().next().unwrap();
+    let tlv_array = TLVList::new(wb.as_slice()).iter().next().unwrap();
     tlv_array
 }
 


### PR DESCRIPTION
Changing this still compiles, however unit tests for me always failed. Before the patch:

```
failures:
    data_model::attributes::test_read_success
    data_model::attributes::test_read_unsupported_fields
    data_model::attributes::test_read_wc_endpoint_only_1_has_cluster
    data_model::attributes::test_write_success
    data_model::attributes::test_write_wc_endpoint
    data_model::commands::test_invoke_cmd_wc_endpoint_only_1_has_cluster
    data_model::commands::test_invoke_cmds_success
    data_model::commands::test_invoke_cmds_unsupported_fields

test result: FAILED. 4 passed; 8 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

AFTER the patch

```
failures:
    data_model::attributes::test_read_success
    data_model::attributes::test_read_wc_endpoint_all_have_clusters
    data_model::attributes::test_read_wc_endpoint_only_1_has_cluster
    data_model::attributes::test_read_wc_endpoint_wc_attribute
    data_model::attributes::test_write_success
    data_model::commands::test_invoke_cmd_wc_endpoint_all_have_clusters

test result: FAILED. 6 passed; 6 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

it seems more things pass (specifically some invoke bits) but I am unsure why ... the change is supposed to be a noop. Guessing some unwrap/mutability bits. Please see if this makes sense.