### PR TITLE
 Implement sys_publish_service for Linux based on libmdns

### DIFF
--- a/matter/Cargo.toml
+++ b/matter/Cargo.toml
@@ -47,6 +47,10 @@ safemem = "0.3.3"
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 async-channel = "1.6"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libmdns = "0.7"
+lazy_static = "1.4.0"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 astro-dnssd = "0.3"
 

--- a/matter/src/sys/sys_linux.rs
+++ b/matter/src/sys/sys_linux.rs
@@ -1,15 +1,46 @@
 use crate::error::Error;
-use log::error;
+use std::vec::Vec;
+use log::info;
+use lazy_static::lazy_static;
+use std::sync::{Arc, Mutex};
+use libmdns::{Service, Responder};
 
 #[allow(dead_code)]
-pub struct SysMdnsService {}
+pub struct SysMdnsService {
+    service: Service,
+}
 
+lazy_static!{
+    static ref RESPONDER: Arc<Mutex<Responder>> = Arc::new(Mutex::new(Responder::new().unwrap()));
+}
+
+/// Publish a mDNS service
+/// name - can be a service name (comma separate subtypes may follow)
+/// regtype - registration type (e.g. _matter_.tcp etc)
+/// port - the port
 pub fn sys_publish_service(
-    _name: &str,
-    _regtype: &str,
-    _port: u16,
-    _txt_kvs: &[[&str; 2]],
+    name: &str,
+    regtype: &str,
+    port: u16,
+    txt_kvs: &[[&str; 2]],
 ) -> Result<SysMdnsService, Error> {
-    error!("Linux is not yet supported for MDNS Service");
-    Ok(SysMdnsService {})
+    info!("mDNS Registration Type {}", regtype);
+    info!("mDNS properties {:?}", txt_kvs);
+
+    let mut properties = Vec::new();
+    for kvs in txt_kvs {
+        info!("mDNS TXT key {} val {}", kvs[0], kvs[1]);
+        properties.push(format!("{}={}", kvs[0], kvs[1]));
+    }
+    let properties: Vec<&str> = properties.iter().map(|entry| entry.as_str()).collect();
+
+    let responder = RESPONDER.lock().map_err(|_| Error::MdnsError)?;
+    let service = responder.register(
+        regtype.to_owned(),
+        name.to_owned(),
+        port,
+        &properties,
+    );
+
+    Ok(SysMdnsService {service})
 }


### PR DESCRIPTION
This sugests using libmdns for Linux MDNS advertisements.

Whereas this works well for comissioning, the application does not seem to receive onoff commands:

`RUST_LOG="matter" cargo run --example onoff_light`
```
[2022-09-13T15:57:17Z INFO  matter::fabric] MDNS Service Name: DC14FBA3A8A89255-0000000000BC5C01
[2022-09-13T15:57:17Z INFO  matter::sys::sys_linux] mDNS Registration Type _matter._tcp
[2022-09-13T15:57:17Z INFO  matter::sys::sys_linux] mDNS properties []
[2022-09-13T15:57:17Z INFO  matter::fabric] Adding new fabric at index 1
Added OnOff Light Device type at endpoint id: 1
Data Model now is: node:
endpoint 0: clusters:[ { id:29, attrs[ 65531: custom-attribute, 1: custom-attribute ],  },  { id:40, attrs[ 65531: custom-attribute, 2: 65521, 4: 32770, 7: 2, 9: 1 ],  },  { id:48, attrs[ 65531: custom-attribute, 0: 0, 2: 2, 3: 2, 1: custom-attribute ],  },  { id:49, attrs[ 65531: custo
m-attribute, 65532: 2 ],  },  { id:62, attrs[ 65531: custom-attribute ],  },  { id:31, attrs[ 65531: custom-attribute, 0: custom-attribute, 1: custom-attribute, 2: 4, 3: 3, 4: 3 ],  }]
endpoint 1: clusters:[ { id:29, attrs[ 65531: custom-attribute, 1: custom-attribute ],  },  { id:6, attrs[ 65531: custom-attribute, 0: false ],  }]
```

`chip-tool onoff off 12344321 1`
```
[1663084119.051395][81036:81036] CHIP:DL: ChipLinuxStorage::Init: Using KVS config file: /tmp/chip_kvs
[1663084119.052536][81036:81036] CHIP:DL: ChipLinuxStorage::Init: Using KVS config file: /tmp/chip_factory.ini
[1663084119.052557][81036:81036] CHIP:DL: ChipLinuxStorage::Init: Using KVS config file: /tmp/chip_config.ini
[1663084119.052565][81036:81036] CHIP:DL: ChipLinuxStorage::Init: Using KVS config file: /tmp/chip_counters.ini
[1663084119.052616][81036:81036] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-HmLZ7v)
[1663084119.052706][81036:81036] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
[1663084119.052711][81036:81036] CHIP:DL: NVS set: chip-counters/reboot-count = 96 (0x60)
[1663084119.052975][81036:81036] CHIP:DL: Got Ethernet interface: enp11s0
[1663084119.053101][81036:81036] CHIP:DL: Found the primary Ethernet interface:enp11s0
[1663084119.054039][81036:81036] CHIP:DL: Got WiFi interface: wlp9s0
[1663084119.054050][81036:81036] CHIP:DL: Failed to reset WiFi statistic counts
[1663084119.054068][81036:81036] CHIP:IN: UDP::Init bind&listen port=0
[1663084119.054082][81036:81036] CHIP:IN: UDP::Init bound to port=40650
[1663084119.054084][81036:81036] CHIP:IN: UDP::Init bind&listen port=0
[1663084119.054091][81036:81036] CHIP:IN: UDP::Init bound to port=57009
[1663084119.054093][81036:81036] CHIP:IN: BLEBase::Init - setting/overriding transport
[1663084119.054095][81036:81036] CHIP:IN: TransportMgr initialized
[1663084119.054100][81036:81036] CHIP:FP: Initializing FabricTable from persistent storage
[1663084119.054126][81036:81036] CHIP:TS: Last Known Good Time: 2022-09-06T15:14:17
[1663084119.054429][81036:81036] CHIP:FP: Fabric index 0x1 was retrieved from storage. Compressed FabricId 0xDC14FBA3A8A89255, FabricId 0x0000000000000001, NodeId 0x000000000001B669, VendorId 0xFFF1
[1663084119.054703][81036:81036] CHIP:ZCL: Using ZAP configuration...
[1663084119.054837][81036:81036] CHIP:DL: MDNS failed to join multicast group on enp11s0 for address type IPv4: ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:758: Inet Error 0x00000110: Address not found
[1663084119.055161][81036:81036] CHIP:DL: MDNS failed to join multicast group on wlp9s0 for address type IPv4: ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:758: Inet Error 0x00000110: Address not found
[1663084119.055255][81036:81036] CHIP:CTL: System State Initialized...
[1663084119.055265][81036:81036] CHIP:CTL: Stopping commissioning discovery over DNS-SD
[1663084119.055277][81036:81036] CHIP:CTL: Setting attestation nonce to random value
[1663084119.055283][81036:81036] CHIP:CTL: Setting CSR nonce to random value
[1663084119.055292][81036:81036] CHIP:IN: UDP::Init bind&listen port=5550
[1663084119.055300][81036:81036] CHIP:IN: UDP::Init bound to port=5550
[1663084119.055309][81036:81036] CHIP:IN: UDP::Init bind&listen port=5550
[1663084119.055321][81036:81036] CHIP:IN: UDP::Init bound to port=5550
[1663084119.055324][81036:81036] CHIP:IN: TransportMgr initialized
[1663084119.055383][81036:81041] CHIP:DL: CHIP task running
[1663084119.055443][81036:81041] CHIP:CTL: Stopping commissioning discovery over DNS-SD
[1663084119.055469][81036:81041] CHIP:CTL: Setting attestation nonce to random value
[1663084119.055490][81036:81041] CHIP:CTL: Setting CSR nonce to random value
[1663084119.055677][81036:81041] CHIP:CTL: Generating NOC
[1663084119.055853][81036:81041] CHIP:FP: Validating NOC chain
[1663084119.056135][81036:81041] CHIP:FP: NOC chain validation successful
[1663084119.056157][81036:81041] CHIP:FP: Updated fabric at index: 0x1, Node ID: 0x000000000001B669
[1663084119.056161][81036:81041] CHIP:TS: Last Known Good Time: 2022-09-06T15:14:17
[1663084119.056163][81036:81041] CHIP:TS: New proposed Last Known Good Time: 2021-01-01T00:00:00
[1663084119.056165][81036:81041] CHIP:TS: Retaining current Last Known Good Time
[1663084119.056364][81036:81041] CHIP:FP: Metadata for Fabric 0x1 persisted to storage.
[1663084119.056580][81036:81041] CHIP:TS: Committing Last Known Good Time to storage: 2022-09-06T15:14:17
[1663084119.056753][81036:81041] CHIP:CTL: Joined the fabric at index 1. Compressed fabric ID is: 0x0000000000000000
[1663084119.056760][81036:81041] CHIP:IN: UDP::Init bind&listen port=5550
[1663084119.056769][81036:81041] CHIP:IN: UDP::Init bound to port=5550
[1663084119.056771][81036:81041] CHIP:IN: UDP::Init bind&listen port=5550
[1663084119.056777][81036:81041] CHIP:IN: UDP::Init bound to port=5550
[1663084119.056779][81036:81041] CHIP:IN: TransportMgr initialized
[1663084119.057755][81036:81041] CHIP:TOO: Sending command to node 0xbc5c01
[1663084119.057760][81036:81041] CHIP:CSM: FindOrEstablishSession: PeerId = [1:0000000000BC5C01]
[1663084119.057763][81036:81041] CHIP:CSM: FindOrEstablishSession: No existing OperationalSessionSetup instance found
[1663084119.057769][81036:81041] CHIP:CTL: OperationalSessionSetup[1:0000000000BC5C01]: State change 1 --> 2
[1663084119.057832][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on enp11s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084119.057915][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on wlp9s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084119.057941][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on docker0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084119.057945][81036:81041] CHIP:DIS: mDNS broadcast had only partial success: 5 successes and 3 failures.
[1663084119.257807][81036:81041] CHIP:DIS: Checking node lookup status after 200 ms
[1663084120.058243][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on enp11s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084120.058442][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on wlp9s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084120.058498][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on docker0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084120.058505][81036:81041] CHIP:DIS: mDNS broadcast had only partial success: 3 successes and 3 failures.
[1663084122.059542][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on enp11s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084122.059773][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on wlp9s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084122.059838][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on docker0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084122.059852][81036:81041] CHIP:DIS: mDNS broadcast had only partial success: 3 successes and 3 failures.
[1663084126.059687][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on enp11s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084126.059904][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on wlp9s0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084126.059953][81036:81041] CHIP:DIS: Warning: Attempt to mDNS broadcast failed on docker0:  ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:406: OS Error 0x02000065: Network is unreachable
[1663084126.059959][81036:81041] CHIP:DIS: mDNS broadcast had only partial success: 3 successes and 3 failures.
[1663084134.058218][81036:81041] CHIP:DIS: Checking node lookup status after 15001 ms
[1663084134.058267][81036:81041] CHIP:DIS: OperationalSessionSetup[1:0000000000BC5C01]: operational discovery failed: ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp:174: CHIP Error 0x00000032: Timeout
[1663084134.058281][81036:81041] CHIP:-: ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp:174: CHIP Error 0x00000032: Timeout at ../Projects/connectedhomeip/examples/chip-tool/commands/clusters/ModelCommand.cpp:62
[1663084134.058496][81036:81036] CHIP:CTL: Shutting down the commissioner
[1663084134.058530][81036:81036] CHIP:CTL: Stopping commissioning discovery over DNS-SD
[1663084134.058595][81036:81036] CHIP:CTL: Shutting down the controller
[1663084134.058618][81036:81036] CHIP:IN: Expiring all sessions for fabric 0x1!!
[1663084134.058626][81036:81036] CHIP:FP: Forgetting fabric 0x1
[1663084134.058645][81036:81036] CHIP:TS: Pending Last Known Good Time: 2022-09-06T15:14:17
[1663084134.058773][81036:81036] CHIP:TS: Previous Last Known Good Time: 2022-09-06T15:14:17
[1663084134.058781][81036:81036] CHIP:TS: Reverted Last Known Good Time to previous value
[1663084134.058812][81036:81036] CHIP:CTL: Shutting down the commissioner
[1663084134.058821][81036:81036] CHIP:CTL: Stopping commissioning discovery over DNS-SD
[1663084134.058844][81036:81036] CHIP:CTL: Shutting down the controller
[1663084134.058852][81036:81036] CHIP:CTL: Shutting down the System State, this will teardown the CHIP Stack
[1663084134.059164][81036:81036] CHIP:DMG: IM WH moving to [Uninitialized]
[1663084134.059176][81036:81036] CHIP:DMG: IM WH moving to [Uninitialized]
[1663084134.059181][81036:81036] CHIP:DMG: IM WH moving to [Uninitialized]
[1663084134.059186][81036:81036] CHIP:DMG: IM WH moving to [Uninitialized]
[1663084134.059197][81036:81036] CHIP:DMG: All ReadHandler-s are clean, clear GlobalDirtySet
[1663084134.059226][81036:81036] CHIP:BLE: BleConnectionDelegate::CancelConnection is not implemented.
[1663084134.059434][81036:81036] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-HHa4ZS)
[1663084134.059796][81036:81036] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
[1663084134.059820][81036:81036] CHIP:DL: NVS set: chip-counters/total-operational-hours = 0 (0x0)
[1663084134.059835][81036:81036] CHIP:DL: Inet Layer shutdown
[1663084134.059844][81036:81036] CHIP:DL: BLE shutdown
[1663084134.059852][81036:81036] CHIP:DL: System Layer shutdown
[1663084134.059888][81036:81036] CHIP:TOO: Run command failure: ../Projects/connectedhomeip/examples/chip-tool/third_party/connectedhomeip/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp:174: CHIP Error 0x00000032: Timeout
```